### PR TITLE
semicolons -> \n in class diagrams

### DIFF
--- a/src/sequence-renderer.js
+++ b/src/sequence-renderer.js
@@ -37,11 +37,6 @@ module.exports = function(actors, signals, uids, isDark)
       this.draw_actors(y);
       this.draw_signals(y + this._actors_height);
     };
-
-    function reformatText(text)
-    {
-      return text.replace(/\\ /g, " ").replace(/\\n/g, "\n");
-    }    
     
     this.layout = function() 
     {
@@ -50,7 +45,7 @@ module.exports = function(actors, signals, uids, isDark)
 
       this.actors.forEach(function(a) 
       {
-        var text = reformatText(a.label);
+        var text = a.label;
         var bb = this.svg_.getTextSize(text);
         a.text_bb = bb;
 
@@ -84,7 +79,7 @@ module.exports = function(actors, signals, uids, isDark)
       signals.forEach(function(s) {
         var a, b; // Indexes of the left and right actors involved
 
-        var text = reformatText(s.message);
+        var text = s.message;
         var bb = this.svg_.getTextSize(text);
 
         s.text_bb = bb;
@@ -264,7 +259,6 @@ module.exports = function(actors, signals, uids, isDark)
 
     this.draw_text = function (x, y, text, dontDrawBox, color) 
     {
-        var text = reformatText(text);
         var t = this.svg_.createText(text, x, y, color);
 
         if (!dontDrawBox) 

--- a/src/yuml2dot-utils.js
+++ b/src/yuml2dot-utils.js
@@ -13,8 +13,7 @@ module.exports = function()
         function replaceChar(c)
         {
             c = c.replace('{', '\\{').replace('}', '\\}');
-            c = c.replace(';', '\\n');
-            c = c.replace(' ', '\\ ');
+            c = c.replace(';', '\n');
             c = c.replace('<', '\\<').replace('>', '\\>');
             // c = c.replace('\\n\\n', '\\n');
             return c;
@@ -128,7 +127,7 @@ module.exports = function()
             lines = label.split('|');
 
         for (var j=0; j<lines.length; j++)
-            lines[j] = wordwrap(lines[j], wrap, "\\n");
+            lines[j] = wordwrap(lines[j], wrap, "\n");
 
         label = lines.join('|');
 
@@ -166,7 +165,7 @@ module.exports = function()
         
             if (obj.label.includes("|")) {
               const ESCAPED_CHARS = {
-                "\\n": "<BR/>",
+                "\n": "<BR/>",
                 "&": "&amp;",
                 "<": "&lt;",
                 ">": "&gt;",


### PR DESCRIPTION
A regression had been added with #2 which replaced most of record-based shapes by rectangle shapes or HTML-like labels. However, the fix did not include the changes to handle correctly line breaks or even spaces (spaces were rendered `\ ` instead of ` `).

Fix #4