### PR TITLE
Add support for bg customization on class elements

### DIFF
--- a/src/yuml2dot-utils.js
+++ b/src/yuml2dot-utils.js
@@ -171,8 +171,9 @@ module.exports = function()
                 ">": "&gt;",
               };
               // If label contains a pipe, we need to use an HTML-like label
-              return (
-                '[fontsize=10,label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="9">' +
+              return `[fontsize=10,label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="9" ${
+                  obj.fillcolor ? `BGCOLOR="${obj.fillcolor}"` : ""
+                } ${obj.fontcolor ? `COLOR="${obj.fontcolor}"` : ""}>${
                 obj.label
                   .split("|")
                   .map(text => {
@@ -189,9 +190,7 @@ module.exports = function()
                     htmlTDNode += "</TD>";
                     return `<TR>${htmlTDNode}</TR>`;
                   })
-                  .join("") +
-                "</TABLE>>]"
-              );
+                  .join("")}</TABLE>>]`;
             }
         
             // To avoid this issue, we can use a "rectangle" shape


### PR DESCRIPTION
A regression appeared with #2, which replaced most of record-based shapes by rectangle shapes or HTML-like labels. However, the fix did not pass the color properties of the record-based shape to the HTML-like label - which can be use to customize class elements.

Fixes: https://github.com/jaime-olivares/yuml-diagram/issues/14