### PR TITLE
explicitly fill: none for open arrow

### DIFF
--- a/src/svg-builder.js
+++ b/src/svg-builder.js
@@ -122,7 +122,7 @@ module.exports = function(isDark)
         openArrow.setAttribute('markerHeight', '6');
         openArrow.setAttribute('orient', 'auto');
 
-        openArrowPath.setAttribute('style', 'stroke-width: 1; stroke: ' + (isDark ? 'white;' : 'black;'));
+        openArrowPath.setAttribute('style', 'stroke-width: 1; fill: none; stroke: ' + (isDark ? 'white;' : 'black;'));
 
         var svg = this.root_.firstChild; 
         svg.appendChild(defs);


### PR DESCRIPTION
Open arrow currently renders filled in for me... Pay attention to the arrow head.

actual | expected
--- | ---
![filled](https://user-images.githubusercontent.com/10444/58581158-be41b200-8203-11e9-9c28-32ac3ac96b0c.png) | ![not filled](https://user-images.githubusercontent.com/10444/58592965-97dd4000-821e-11e9-9b51-d212d9ee784e.png)


See https://observablehq.com/@visnup/yuml