### PR TITLE
fix: ⛑ Fix wrong path to data/rgb.txt

### DIFF
--- a/src/utils/yuml2dot-utils.js
+++ b/src/utils/yuml2dot-utils.js
@@ -248,7 +248,7 @@ module.exports = function()
         else
             colorTable = {};
 
-        var rgb = fs.readFileSync(__dirname + "/../data/rgb.txt", {encoding:"utf8", flag:"r"}).split('\n');
+        var rgb = fs.readFileSync(__dirname + "/../../data/rgb.txt", {encoding:"utf8", flag:"r"}).split('\n');
         for (var i=0; i<rgb.length; i++)
         {
             var parts = /^(\d+) (\d+) (\d+) (.*)$/.exec(rgb[i]);


### PR DESCRIPTION
This pull request fixes an issue with a wrong path to data/rgb.txt in the loadColors function (file src/utils/yuml2dot-utils.js).

This causes an error when generating diagrams as explained in this issue:

[https://github.com/jaime-olivares/yuml-diagram/issues/26#issue-529942843](https://github.com/jaime-olivares/yuml-diagram/issues/26#issue-529942843)

