### PR TITLE
fix multi-row state shapes and put emphasis on class names

### DIFF
--- a/src/diagrams/state-diagram.js
+++ b/src/diagrams/state-diagram.js
@@ -84,8 +84,6 @@ module.exports = function(specLines, options)
                     else
                     {
                         label = formatLabel(label, 20, true);
-                        if (type == "record")
-                            label = "{" + label + "}";
 
                         var node = {
                             shape: type,


### PR DESCRIPTION
> In UML, states are represented as rounded rectangles labeled with state names.
> Source: [Wikipedia](https://en.wikipedia.org/wiki/UML_state_machine#Basic_UML_state_diagrams)

`yuml-diagram` does not respect that on multi-line states, this PR fixes that.

Also, it fixes a bug where brackets would be added to the state:

![State machine example](https://github.com/jaime-olivares/yuml-diagram/wiki/diagrams/example.state.svg?sanitize=true)

Note the graph says `{Simulator Running}` instead of `Simulator Running`, and how the graph doesn't use rounded rectangles for the `Simulator paused` state.
With this fix, it looks like this:

![State machine example](https://github.com/aduh95/yuml-diagram/wiki/state.svg?sanitize=true)